### PR TITLE
Bump (and relax) the createsend dependency.

### DIFF
--- a/create_send_rails.gemspec
+++ b/create_send_rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w{lib}
 
   s.add_dependency 'actionmailer', '>= 3.0.0'
-  s.add_dependency 'createsend', '4.1.1'
+  s.add_dependency 'createsend', '~> 4.1.0'
 
   s.add_development_dependency 'byebug', '8.2.1'
   s.add_development_dependency 'codeclimate-test-reporter'

--- a/create_send_rails.gemspec
+++ b/create_send_rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w{lib}
 
   s.add_dependency 'actionmailer', '>= 3.0.0'
-  s.add_dependency 'createsend', '4.1.0'
+  s.add_dependency 'createsend', '4.1.1'
 
   s.add_development_dependency 'byebug', '8.2.1'
   s.add_development_dependency 'codeclimate-test-reporter'

--- a/create_send_rails.gemspec
+++ b/create_send_rails.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = %w{spec}
   s.require_paths = %w{lib}
 
+  s.add_dependency 'activesupport', '>= 3.0.0'
   s.add_dependency 'actionmailer', '>= 3.0.0'
   s.add_dependency 'createsend', '~> 4.1.0'
 
@@ -26,8 +27,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mime-types', '~> 1.25.1'
   s.add_development_dependency 'pry-byebug', '3.3.0'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '~> 2.14.0'
+  s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '0.37.2'
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
-  s.add_development_dependency 'simplecov', '~> 0.11.2'
+  s.add_development_dependency 'simplecov', '~> 0.13.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
-require 'codeclimate-test-reporter'
 require 'simplecov'
 SimpleCov.start
-CodeClimate::TestReporter.start
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
+require 'active_support'
+require 'active_support/core_ext/object/try'
 require 'create_send_rails'


### PR DESCRIPTION
4.1.1 of the createsend gem updated some of their dependencies (e.g allowing JSON 2.x instead of just the 1.x range) and I needed these changes so I could add createsend_rails to my project.